### PR TITLE
Remove failing command `kubescape version`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,6 @@ curl -sL -o /usr/bin/kubescape \
     
 chmod +x /usr/bin/kubescape
 
-kubescape --version 
-
 echo "Output format is set to: $4"
 
 if [[ "$4" == "json" ]]; then  


### PR DESCRIPTION
May fix issue #4

Try locally to run the command for new version of kubescape.

The other option is to note the version compatibility.